### PR TITLE
fix upload driver licence

### DIFF
--- a/src/clients/driver/drivers.client.ts
+++ b/src/clients/driver/drivers.client.ts
@@ -68,14 +68,14 @@ export class DriversClient {
   async notifyFileUploaded(
     driverId: string,
     fileType: FileType,
-    fileKey: string,
+    fileUrl: string,
     contentType: string,
     fileName: string,
   ): Promise<any> {
     const notifyDto: NotifyFileUploadedDto = {
       userId: driverId,
       fileType: fileType,
-      fileKey: fileKey,
+      fileUrl: fileUrl,
       contentType: contentType,
       fileName: fileName,
     };

--- a/src/clients/driver/dto/notify-file-uploaded.dto.ts
+++ b/src/clients/driver/dto/notify-file-uploaded.dto.ts
@@ -3,7 +3,7 @@ import { FileType } from 'src/modules/drivers/enum/file-type.enum';
 export class NotifyFileUploadedDto {
   userId: string;
   fileType: FileType;
-  fileKey: string;
+  fileUrl: string;
   contentType: string;
   fileName: string;
 }

--- a/src/modules/drivers/drivers.service.ts
+++ b/src/modules/drivers/drivers.service.ts
@@ -39,14 +39,14 @@ export class DriversService {
   async notifyFileUploaded(
     driverId: string,
     fileType: FileType,
-    fileKey: string,
+    fileUrl: string,
     contentType: string,
     fileName: string,
   ): Promise<any> {
     return this.driversClient.notifyFileUploaded(
       driverId,
       fileType,
-      fileKey,
+      fileUrl,
       contentType,
       fileName,
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Upload notification now requires fileUrl instead of fileKey across the app/API. Update integrations to pass a URL; the fileKey parameter is no longer accepted.

- Refactor
  - Standardized naming to fileUrl across related services and payloads; no other parameters or behaviors changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->